### PR TITLE
Add two page curl composable

### DIFF
--- a/demo/src/main/kotlin/eu/wewox/pagecurl/Example.kt
+++ b/demo/src/main/kotlin/eu/wewox/pagecurl/Example.kt
@@ -38,4 +38,8 @@ enum class Example(
         "Back-Page Configuration in Page Curl",
         "Example how to customize the back-page (the back of the page user see during the drag or animation)"
     ),
+    TwoPagePageCurl(
+        "Two-Page Configuration in Page Curl",
+        "Example how to use two-page configuration (showing two pages at once, like in a book or magazine)"
+    ),
 }

--- a/demo/src/main/kotlin/eu/wewox/pagecurl/HowToPageData.kt
+++ b/demo/src/main/kotlin/eu/wewox/pagecurl/HowToPageData.kt
@@ -143,5 +143,20 @@ data class HowToPageData(
                 "That is the last page, you cannot go further \uD83D\uDE09",
             )
         )
+
+        val twoPageCurlHowToPages = listOf(
+            HowToPageData(
+                "Page Start",
+                "This is a simple demo of the PageCurl. Swipe to the left to turn the page.",
+            ),
+            HowToPageData(
+                "Here is the next page",
+                "This is the next page. Swipe to the left to turn the page.",
+            ),
+            HowToPageData(
+                "Last Page",
+                "That is the last page, you cannot go further \uD83D\uDE09",
+            ),
+        )
     }
 }

--- a/demo/src/main/kotlin/eu/wewox/pagecurl/MainActivity.kt
+++ b/demo/src/main/kotlin/eu/wewox/pagecurl/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import eu.wewox.pagecurl.screens.BackPagePageCurlScreen
 import eu.wewox.pagecurl.screens.InteractionConfigInPageCurlScreen
+import eu.wewox.pagecurl.screens.TwoPagePageCurlScreen
 import eu.wewox.pagecurl.screens.PagingPageCurlScreen
 import eu.wewox.pagecurl.screens.SettingsPageCurlScreen
 import eu.wewox.pagecurl.screens.ShadowInPageCurlScreen
@@ -54,6 +55,7 @@ class MainActivity : ComponentActivity() {
                             Example.InteractionConfigInPageCurl -> InteractionConfigInPageCurlScreen()
                             Example.ShadowPageCurl -> ShadowInPageCurlScreen()
                             Example.BackPagePageCurl -> BackPagePageCurlScreen()
+                            Example.TwoPagePageCurl -> TwoPagePageCurlScreen()
                         }
                     }
                 }

--- a/demo/src/main/kotlin/eu/wewox/pagecurl/screens/TwoPagePageCurlScreen.kt
+++ b/demo/src/main/kotlin/eu/wewox/pagecurl/screens/TwoPagePageCurlScreen.kt
@@ -1,0 +1,88 @@
+@file:OptIn(ExperimentalPageCurlApi::class)
+@file:Suppress("MagicNumber")
+
+package eu.wewox.pagecurl.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import eu.wewox.pagecurl.ExperimentalPageCurlApi
+import eu.wewox.pagecurl.HowToPageData
+import eu.wewox.pagecurl.config.PageCurlConfig
+import eu.wewox.pagecurl.config.rememberPageCurlConfig
+import eu.wewox.pagecurl.page.NextBackPageCurl
+import eu.wewox.pagecurl.ui.SpacingLarge
+import eu.wewox.pagecurl.ui.SpacingMedium
+
+/**
+ * Two-Page Configuration in Page Curl.
+ * This screen demonstrates how to use the PageCurl library to create a two-page curl effect.
+ */
+@Composable
+fun TwoPagePageCurlScreen() {
+    Box(Modifier.fillMaxSize()) {
+        val pages = remember { HowToPageData.twoPageCurlHowToPages }
+        NextBackPageCurl(
+            count = pages.size,
+            config = rememberPageCurlConfig(
+                dragInteraction = PageCurlConfig.StartEndDragInteraction(
+                    PageCurlConfig.DragInteraction.PointerBehavior.PageEdge
+                )
+            ),
+        ) { index ->
+            ShowTwoPage(index, pages[index])
+        }
+    }
+}
+
+@Composable
+fun ShowTwoPage(
+    index: Int,
+    page: HowToPageData,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(SpacingLarge),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = page.title,
+                style = MaterialTheme.typography.headlineMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.weight(1f)
+            )
+
+            Text(
+                text = page.message,
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        Text(
+            text = index.toString(),
+            color = MaterialTheme.colorScheme.background,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .background(MaterialTheme.colorScheme.onBackground, RoundedCornerShape(topStartPercent = 100))
+                .padding(SpacingMedium)
+        )
+    }
+}

--- a/pagecurl/src/main/kotlin/eu/wewox/pagecurl/page/NextBackPageCurl.kt
+++ b/pagecurl/src/main/kotlin/eu/wewox/pagecurl/page/NextBackPageCurl.kt
@@ -1,0 +1,110 @@
+package eu.wewox.pagecurl.page
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import eu.wewox.pagecurl.ExperimentalPageCurlApi
+import eu.wewox.pagecurl.config.PageCurlConfig
+import eu.wewox.pagecurl.config.rememberPageCurlConfig
+
+/**
+ * Shows the pages which may be turned by drag or tap gestures.
+ * This composable is used to create a page curl effect with next and back pages.
+ *
+ * @param count The count of pages.
+ * @param modifier The modifier for this composable.
+ * @param state The state of the PageCurl. Use this to programmatically change the current page or observe changes.
+ * @param config The configuration for PageCurl.
+ * @param content The content lambda to provide the page composable. Receives the page number.
+ */
+@SuppressLint("UnusedBoxWithConstraintsScope")
+@ExperimentalPageCurlApi
+@Composable
+public fun NextBackPageCurl(
+    count: Int,
+    modifier: Modifier = Modifier,
+    state: PageCurlState = rememberPageCurlState(),
+    config: PageCurlConfig = rememberPageCurlConfig(),
+    content: @Composable (Int) -> Unit
+) {
+    val scope = rememberCoroutineScope()
+
+    BoxWithConstraints(modifier) {
+        state.setup(count, constraints)
+
+        val updatedCurrent by rememberUpdatedState(state.current)
+        val internalState by rememberUpdatedState(state.internalState ?: return@BoxWithConstraints)
+
+        val updatedConfig by rememberUpdatedState(config)
+
+        val dragGestureModifier = when (val interaction = updatedConfig.dragInteraction) {
+            is PageCurlConfig.GestureDragInteraction ->
+                Modifier
+                    .dragGesture(
+                        dragInteraction = interaction,
+                        state = internalState,
+                        enabledForward = updatedConfig.dragForwardEnabled && updatedCurrent < state.max - 1,
+                        enabledBackward = updatedConfig.dragBackwardEnabled && updatedCurrent > 0,
+                        scope = scope,
+                        onChange = { state.current = updatedCurrent + it }
+                    )
+
+            is PageCurlConfig.StartEndDragInteraction ->
+                Modifier
+                    .dragStartEnd(
+                        dragInteraction = interaction,
+                        state = internalState,
+                        enabledForward = updatedConfig.dragForwardEnabled && updatedCurrent < state.max - 1,
+                        enabledBackward = updatedConfig.dragBackwardEnabled && updatedCurrent > 0,
+                        scope = scope,
+                        onChange = { state.current = updatedCurrent + it }
+                    )
+        }
+
+        Box(
+            Modifier
+                .then(dragGestureModifier)
+                .tapGesture(
+                    config = updatedConfig,
+                    scope = scope,
+                    onTapForward = state::next,
+                    onTapBackward = state::prev,
+                )
+        ) {
+            // Wrap in key to synchronize state updates
+            key(updatedCurrent, internalState.forward.value, internalState.backward.value) {
+                if (updatedCurrent + 1 < state.max) {
+                    content(updatedCurrent + 1)
+                }
+
+                if (updatedCurrent < state.max) {
+                    val forward = internalState.forward.value
+                    Box(Modifier.drawFlatContent(forward.top, forward.bottom)) {
+                        content(updatedCurrent)
+                    }
+                    Box(Modifier.drawBothSideCurl(updatedConfig, forward.top, forward.bottom)) {
+                        if (updatedCurrent + 1 < state.max) {
+                            content(updatedCurrent + 1)
+                        }
+                    }
+                }
+
+                if (updatedCurrent > 0) {
+                    val backward = internalState.backward.value
+                    Box(Modifier.drawFlatContent(backward.top, backward.bottom)) {
+                        content(updatedCurrent - 1)
+                    }
+                    Box(Modifier.drawBothSideCurl(updatedConfig, backward.top, backward.bottom)) {
+                        content(updatedCurrent)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Add Two-Page Display with Backside Page Curl Effect

This PR introduces a new ```NextBackPageCurl``` component that displays two pages simultaneously and ensures that the next page appears on the backside when scrolling, mimicking a book-like page-turning effect.

```kotlin
NextBackPageCurl(
    count = pages.size,
    config = rememberPageCurlConfig(
        dragInteraction = PageCurlConfig.StartEndDragInteraction(
            PageCurlConfig.DragInteraction.PointerBehavior.PageEdge
        )
    ),
) { index ->
    ShowTwoPage(index, pages[index])
}
```

## Example

https://github.com/user-attachments/assets/ed2bca3e-74ae-4464-80f6-d5938c61f97d


